### PR TITLE
Add meta info to head

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,5 @@
 baseurl = "https://ffd-microsite-staging.apps.cloud.gov"
 languageCode = "en-us"
-title = "Federal Front Door"
+[params]
+  Title = "Federal Front Door"
+  Description = "The public’s front door to  government services"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -22,8 +22,8 @@
       <section class="usa-banner">
         <div class="usa-grid">
           <div class="usa-banner-content" id="main-content">
-            <h1>Federal Front Door</h1>
-            <h2>The public’s front door to government services</h2>
+            <h1>{{ .Site.Params.Title }}</h1>
+            <h2>{{ .Site.Params.Description }}</h2>
           </div>
         </div>
       </section>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -56,3 +56,9 @@
     ga('set', 'forceSSL', true);
     ga('send', 'pageview');
   </script>
+
+<!-- HTML5 Shiv
+================================================== -->
+{{ `<!--[if lt IE 9]>
+  <script src="` | safeHTML }}{{ .Site.BaseURL }}{{ `assets/js/vendor/html5shiv.js"></script>
+<![endif]-->` | safeHTML }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,7 +11,13 @@
 
 <!-- Title and meta description
 ================================================== -->
-  <title>{{ .Site.Title }}</title>
+  <title>{{ .Site.Params.Title }}</title>
+  <meta property="og:title" content="{{ .Site.Params.Title }}" />
+
+  <meta name="description" content="{{ .Site.Params.Description }}">
+  <meta property="og:description" content="{{ .Site.Params.Description }}" />
+
+  <link rel="canonical" href="{{ .Site.BaseURL }}" />
 
 <!-- Favicons
 ================================================== -->


### PR DESCRIPTION
This adds the meta info (title, description, canonical URL) to the head partial. This also adds HTML5Shiv to the head.

This adds title and description as params to Hugo's config file.

Resolves an item here: https://github.com/18F/ffd-microsite/issues/1#issuecomment-186387861

cc @rogeruiz @yozlet
