### PR TITLE
Fix gulp errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
         "linebreak-style": [ 2, "unix" ],
         "semi": [ 2, "always" ],
         "comma-dangle": [ 1, "always-multiline" ],
-        "no-undef": [ 0 ],
+        "no-undef": [ 2 ],
         "space-before-function-paren": [ 2, "always" ],
         "array-bracket-spacing": [ 2, "always" ],
         "block-spacing": [ 2, "always" ],

--- a/assets/scripts/components/sticky-nav.js
+++ b/assets/scripts/components/sticky-nav.js
@@ -3,8 +3,8 @@ var calculateAnchorPosition = require('./calculate-anchor-position');
 var $nav = $('.js-sticky-nav');
 var STICKY_CLASS_NAME = 'is-sticky-nav';
 
-$('.js-sticky-nav').on('click', 'a', function(e) {
-  var hashLocation  = $(this).attr('href').split('#')[1]; // long url splitting
+$('.js-sticky-nav').on('click', 'a', function (e) {
+  var hashLocation  = $(this).attr('href').split('#')[ 1 ]; // long url splitting
   var scrollTopPos  = calculateAnchorPosition(hashLocation);
 
   //if anchor doesn't exist on the page, or calc fails
@@ -12,12 +12,12 @@ $('.js-sticky-nav').on('click', 'a', function(e) {
   if (scrollTopPos === 0) {
     return true;
   }
-  
+
   e.preventDefault();
 
   /* Firefox needs html, others need body */
   $('body,html').animate({
-    scrollTop: scrollTopPos
+    scrollTop: scrollTopPos,
   }, {
     duration: 200,
     start: function () {
@@ -37,10 +37,10 @@ $('.js-sticky-nav').on('click', 'a', function(e) {
 
       if (link.data('keypress') === true) {
         link.removeData('keypress');
-        section.attr('tabindex','0');
+        section.attr('tabindex', '0');
         section.focus();
       }
-    }
+    },
   });
 });
 
@@ -59,4 +59,4 @@ module.exports = function stickyNav (event) {
     $('body').css('paddingTop', 0);
   }
 
-}
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,9 @@ gulp.task('scss-lint', function (done) {
   }
 
   return gulp.src('./assets/styles/**/*.scss')
-    .pipe(scsslint());
+    .pipe(scsslint({
+      config: './.scss-lint.yml',
+    }));
 
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,7 +67,10 @@ gulp.task('eslint', function (done) {
   }
 
   return gulp.src('./assets/scripts/**/*.js')
-    .pipe(eslint());
+    .pipe(eslint({
+      configFile: './.eslintrc',
+    }))
+    .pipe(eslint.format());
 
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -129,21 +129,27 @@ gulp.task('scripts', [ 'eslint' ], function () {
 });
 
 gulp.task('images', function () {
+
   gutil.log(gutil.colors.cyan('images'), 'Copying image assets');
-  return gulp.src([
-      './assets/images/**/*',
-      './node_modules/uswds/src/img/**/*'
-    ])
-    .pipe(gulp.dest('./static/assets/images'));
+  var stream = gulp.src([
+    './assets/images/**/*',
+    './node_modules/uswds/src/img/**/*',
+  ]);
+
+  return stream.pipe(gulp.dest('./static/assets/images'));
+
 });
 
 gulp.task('fonts', function () {
+
   gutil.log(gutil.colors.cyan('fonts'), 'Copying font assets');
-  return gulp.src([
-      './assets/fonts/**/*',
-      './node_modules/uswds/src/fonts/**/*'
-    ])
-    .pipe(gulp.dest('./static/assets/fonts'));
+  var stream = gulp.src([
+    './assets/fonts/**/*',
+    './node_modules/uswds/src/fonts/**/*',
+  ]);
+
+  return stream.pipe(gulp.dest('./static/assets/fonts'));
+
 });
 
 gulp.task('build', [ 'clean-all' ], function (done) {


### PR DESCRIPTION
This series of patches updates the `gulp watch` to not fail when it encounters errors, and to better report `eslint` errors to the console. Previous to this PR, the `gulp` task would crash needing to be restarted.

This can be tested by running `gulp website` in a terminal window and then creating a syntax or linter error in `assets/scripts/start.js` and checking that the `gulp` task is running along with enhanced linter error / warning reporting.

cc: @maya @juliaelman 
