### PR TITLE
Adding .media_link override and solve for linked image underline.

### DIFF
--- a/assets/styles/homepage.scss
+++ b/assets/styles/homepage.scss
@@ -214,10 +214,12 @@ h2 {
 
 .section-footer-links {
   @include padding(2rem null);
-
-  img {
-    margin-right: 1rem;
-    max-width: 3.4rem;
+  a {
+      margin-right: 1rem;
+      
+    img {
+      max-width: 3.4rem;
+    }
   }
 }
 

--- a/assets/styles/homepage.scss
+++ b/assets/styles/homepage.scss
@@ -14,6 +14,14 @@ p {
   font-size: 1.7rem;
 }
 
+// Below is an override of .media-link to include exclusion 
+// of any "text decoration on hover" issues.
+.media_link {
+  display: inline-block;
+  line-height: 0;
+  text-decoration: none;
+}
+
 .usa-content {
   p {
     max-width: $text-width;

--- a/assets/styles/homepage.scss
+++ b/assets/styles/homepage.scss
@@ -214,12 +214,13 @@ h2 {
 
 .section-footer-links {
   @include padding(2rem null);
+
   a {
-      margin-right: 1rem;
-      
-    img {
-      max-width: 3.4rem;
-    }
+    margin-right: 1rem;
+  }
+
+  img {
+    max-width: 3.4rem;
   }
 }
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -128,13 +128,13 @@
       <!--Footer links BEGIN -->
       <section class="usa-section section-footer-links">
         <div class="usa-grid">
-            <a href="https://usa.gov/">
+            <a class="media_link" href="https://usa.gov/">
               <img src="{{ .Site.BaseURL }}/assets/images/usagov-logo.png" alt="USA.gov logo">
             </a>
-            <a href="https://18f.gsa.gov/">
+            <a class="media_link" href="https://18f.gsa.gov/">
               <img src="{{ .Site.BaseURL }}/assets/images/18f-logo.png" alt="18F logo">
             </a>
-            <a href="http://gsa.gov/">
+            <a class="media_link" href="http://gsa.gov/">
               <img src="{{ .Site.BaseURL }}/assets/images/gsa-logo.png" alt="GSA logo">
             </a>
         </div>


### PR DESCRIPTION
This pull request resolves an underline issue that is happening on images that are wrapped in `<a>`. See gif below:

![d70fjrjocm](https://cloud.githubusercontent.com/assets/955558/13330635/a86c9322-dbc7-11e5-80b3-95828d6d3e05.gif)

Did some sleuthing and it looks like there was a solve created in the Web Design Standards, but it excludes the removal a possible underline as well. Relates to the work completed here:

https://github.com/18F/web-design-standards/pull/833

Overriding for a quick solve now, but will also submit a PR to the Web Design Standards too.
