### PR TITLE
Fix IE9 issue by leveraging jQuery

### DIFF
--- a/assets/scripts/components/sticky-nav.js
+++ b/assets/scripts/components/sticky-nav.js
@@ -49,7 +49,8 @@ module.exports = function stickyNav (event) {
 
   var originalNavigationHeight = $nav.outerHeight(true);
   var bannerHeight = window.innerHeight;
-  var scrollPositionY = window.scrollY + originalNavigationHeight;
+  var scrollY = $(window).scrollTop();
+  var scrollPositionY = scrollY + originalNavigationHeight;
 
   if (scrollPositionY > bannerHeight) {
     $nav.addClass(STICKY_CLASS_NAME);


### PR DESCRIPTION
`window.scrollY` is not supported in IE. So instead of using the `window` property, let's leverage jQuery's `scrollTop()`.
