### PR TITLE
Removing max-width from footer <img> and placing on footer <a> instead.

### DIFF
--- a/assets/styles/homepage.scss
+++ b/assets/styles/homepage.scss
@@ -217,9 +217,6 @@ h2 {
 
   a {
     margin-right: 1rem;
-  }
-
-  img {
     max-width: 3.4rem;
   }
 }


### PR DESCRIPTION
Small PR to fix stacked logo images in footer in Firefox. See image below for how footer on staging currently appears:

<img width="284" alt="screen shot 2016-02-25 at 3 27 35 pm" src="https://cloud.githubusercontent.com/assets/955558/13334073/0fa80660-dbd8-11e5-8b18-56c98ab0623b.png">

Refs #16 
