### PR TITLE
Fix description

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,4 @@ baseurl = "https://ffd-microsite-staging.apps.cloud.gov"
 languageCode = "en-us"
 [params]
   Title = "Federal Front Door"
-  Description = "The public’s front door to  government services"
+  Description = "The public’s front door to government services"


### PR DESCRIPTION
@maya pointed out there was a strange UTF-8 character in the whitespace in the description.

Here's what it looked like, since the diff on Github doesn't properly show the problem:

``` diff
diff --git a/config.toml b/config.toml
index 6a1fab9..bf483da 100644
--- a/config.toml
+++ b/config.toml
@@ -2,4 +2,4 @@ baseurl = "https://ffd-microsite-staging.apps.cloud.gov"
 languageCode = "en-us"
 [params]
   Title = "Federal Front Door"
-  Description = "The public’s front door to<U+2028> government services"
\ No newline at end of file
+  Description = "The public’s front door to government services"
```
