### PR TITLE
Fix config url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://ffd-microsite-staging.apps.cloud.gov"
+baseurl = "https://ffd-microsite-staging.apps.cloud.gov/"
 languageCode = "en-us"
 [params]
   Title = "Federal Front Door"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,7 +12,7 @@
       <div class="usa-disclaimer">
         <div class="usa-grid">
           <span class="usa-disclaimer-official">
-            <img class="usa-flag_icon" src="{{ .Site.BaseURL }}/assets/images/us_flag_small.png" alt="U.S. flag">
+            <img class="usa-flag_icon" src="{{ .Site.BaseURL }}assets/images/us_flag_small.png" alt="U.S. flag">
             An official website of the United States government
           </span>
           <span class="usa-disclaimer-stage">This site is currently in alpha. <a href="https://18f.gsa.gov/dashboard/stages/#alpha">Learn more.</a></span>
@@ -49,14 +49,14 @@
       <div class="usa-grid">
         <div class="usa-width-one-half usa-width-one-half-top">
           <div class="usa-circle-block">
-            <img class="usa-img-circle"  src="{{ .Site.BaseURL }}/assets/images/web_design_standards.svg" alt="Web design standards">
+            <img class="usa-img-circle"  src="{{ .Site.BaseURL }}assets/images/web_design_standards.svg" alt="Web design standards">
           </div>
           <h3 class="usa-graphic-list-heading">Web design standards</h3>
           <p class="usa-graphic-list-text">Use the Standards to create consistent, engaging user experiences across federal government websites. Our open-source UI components and visual style guide reflect industry best practices and conform to Section 508 standards. <a href="https://playbook.cio.gov/designstandards/">View the standards</a></p>
         </div>
         <div class="usa-width-one-half usa-width-one-half-top">
           <div class="usa-circle-block">
-            <img class="usa-img-circle" src="{{ .Site.BaseURL }}/assets/images/proxies_info_sharing.svg" alt="Proxies and information sharing">
+            <img class="usa-img-circle" src="{{ .Site.BaseURL }}assets/images/proxies_info_sharing.svg" alt="Proxies and information sharing">
           </div>
           <h3 class="usa-graphic-list-heading">Proxies and information sharing</h3>
           <p class="usa-graphic-list-text">Many government services don’t allow collaborative interactions, making resources harder to access; we’re researching how to include more interactions by proxy. We’re also investigating how agencies can safely share information with each other in a way that creates better user experiences.</p>
@@ -65,14 +65,14 @@
       <div class="usa-grid">
         <div class="usa-width-one-half">
           <div class="usa-circle-block">
-            <img class="usa-img-circle" src="{{ .Site.BaseURL }}/assets/images/government_transparency.svg" alt="Government transparency">
+            <img class="usa-img-circle" src="{{ .Site.BaseURL }}assets/images/government_transparency.svg" alt="Government transparency">
           </div>
           <h3 class="usa-graphic-list-heading">Government transparency</h3>
           <p class="usa-graphic-list-text">Our research found that folks don’t know what goes on inside the government. This lack of knowledge often translates to a lack of trust, which negatively impacts interactions. We’re focusing on how to provide greater transparency into government processes to improve government-public interactions.</p>
         </div>
         <div class="usa-width-one-half">
           <div class="usa-circle-block">
-            <img class="usa-img-circle" src="{{ .Site.BaseURL }}/assets/images/civic_engagement.svg" alt="Civic engagement">
+            <img class="usa-img-circle" src="{{ .Site.BaseURL }}assets/images/civic_engagement.svg" alt="Civic engagement">
           </div>
           <h3 class="usa-graphic-list-heading">Civic engagement</h3>
           <p class="usa-graphic-list-text">Getting involved with government at any level means having your voice heard and your views represented. Our work on civic engagement shows how public participation at all levels of government helps people gain empowerment and positively impact their communities.</p>
@@ -86,15 +86,15 @@
       <div class="usa-grid">
         <h2>Research report</h2>
         <div class="usa-width-one-third">
-          <img src="{{ .Site.BaseURL }}/assets/images/ffd-research.png" alt="Research">
+          <img src="{{ .Site.BaseURL }}assets/images/ffd-research.png" alt="Research">
         </div>
         <div class="usa-width-two-thirds">
           <h3 class="usa-font-lead">All our work is guided by user research — structured conversations with people from varied populations. This research report highlights our lines of inquiry, provides detailed descriptions of what we learned, and raises questions that warrant further study.</h3>
-          <a class="usa-button usa-button-secondary" href="{{ .Site.BaseURL }}/files/FFD_ResearchReport_0216.pdf" onclick="ga('send', 'event', 'Downloaded PDF report', 'Clicked download of report');">Download the report (PDF)</a>
+          <a class="usa-button usa-button-secondary" href="{{ .Site.BaseURL }}files/FFD_ResearchReport_0216.pdf" onclick="ga('send', 'event', 'Downloaded PDF report', 'Clicked download of report');">Download the report (PDF)</a>
           <span class="usa-text-small">Updated 2/1/16</span>
           <h3>Methodology supplement</h3>
           <p>Want all the specifics of the research we conducted? Download our research methodologies supplement for information on our interview groups, recruiting scripts, interview scripts, and more.</p>
-          <a class="usa-button usa-button-outline" href="{{ .Site.BaseURL }}/files/FFD_Research_Methodology_v11.pdf" onclick="ga('send', 'event', 'Downloaded PDF report', 'Clicked download of supplement report');">Download the supplement (PDF)</a>
+          <a class="usa-button usa-button-outline" href="{{ .Site.BaseURL }}files/FFD_Research_Methodology_v11.pdf" onclick="ga('send', 'event', 'Downloaded PDF report', 'Clicked download of supplement report');">Download the supplement (PDF)</a>
           <span class="usa-text-small">Updated 2/1/16</span>
         </div>
       </div>
@@ -110,13 +110,13 @@
             <p class="usa-font-lead">We’re glad you’re interested in the Federal Front Door — we’d love to hear from you. Send us your questions or feedback, and a member of our team will get back to you shortly.</p>
           </div>
           <div class="usa-width-one-half usa-media">
-            <img class="usa-media-img" src="{{ .Site.BaseURL }}/assets/images/icon-laptop.png" alt="laptop icon">
+            <img class="usa-media-img" src="{{ .Site.BaseURL }}assets/images/icon-laptop.png" alt="laptop icon">
             <div class="usa-media-text">
               <p class="usa-no_margins">Drop us a line at <a href="mailto:federalfrontdoor@gsa.gov">federalfrontdoor@gsa.gov</a>. We’ll respond within a day or two (more likely sooner).</p>
             </div>
           </div>
           <div class="usa-width-one-half usa-media">
-            <img class="usa-media-img" src="{{ .Site.BaseURL }}/assets/images/icon-github.png" alt="GitHub icon">
+            <img class="usa-media-img" src="{{ .Site.BaseURL }}assets/images/icon-github.png" alt="GitHub icon">
             <div class="usa-media-text">
               <p class="usa-no_margins">To learn more about our current work — and to make suggestions — visit our <a href="{{ .Site.Params.Repo }}">GitHub repo</a>.</p>
             </div>
@@ -129,13 +129,13 @@
       <section class="usa-section section-footer-links">
         <div class="usa-grid">
             <a class="media_link" href="https://usa.gov/">
-              <img src="{{ .Site.BaseURL }}/assets/images/usagov-logo.png" alt="USA.gov logo">
+              <img src="{{ .Site.BaseURL }}assets/images/usagov-logo.png" alt="USA.gov logo">
             </a>
             <a class="media_link" href="https://18f.gsa.gov/">
-              <img src="{{ .Site.BaseURL }}/assets/images/18f-logo.png" alt="18F logo">
+              <img src="{{ .Site.BaseURL }}assets/images/18f-logo.png" alt="18F logo">
             </a>
             <a class="media_link" href="http://gsa.gov/">
-              <img src="{{ .Site.BaseURL }}/assets/images/gsa-logo.png" alt="GSA logo">
+              <img src="{{ .Site.BaseURL }}assets/images/gsa-logo.png" alt="GSA logo">
             </a>
         </div>
       </section>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,22 +22,22 @@
 <!-- Favicons
 ================================================== -->
   <!-- 128x128 -->
-  <link rel="shortcut icon" type="image/ico" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon.ico" />
-  <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon.png" />
+  <link rel="shortcut icon" type="image/ico" href="{{ .Site.BaseURL }}assets/images/favicons/favicon.ico" />
+  <link rel="icon" type="image/png" href="{{ .Site.BaseURL }}assets/images/favicons/favicon.png" />
 
   <!-- 192x192, as recommended for Android
   http://updates.html5rocks.com/2014/11/Support-for-theme-color-in-Chrome-39-for-Android
   -->
-  <link rel="icon" type="image/png" sizes="192x192" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon-192.png" />
+  <link rel="icon" type="image/png" sizes="192x192" href="{{ .Site.BaseURL }}assets/images/favicons/favicon-192.png" />
 
   <!-- 57x57 (precomposed) for iPhone 3GS, pre-2011 iPod Touch and older Android devices -->
-  <link rel="apple-touch-icon-precomposed" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon-57.png">
+  <link rel="apple-touch-icon-precomposed" href="{{ .Site.BaseURL }}assets/images/favicons/favicon-57.png">
   <!-- 72x72 (precomposed) for 1st generation iPad, iPad 2 and iPad mini -->
-  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon-72.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ .Site.BaseURL }}assets/images/favicons/favicon-72.png">
   <!-- 114x114 (precomposed) for iPhone 4, 4S, 5 and post-2011 iPod Touch -->
-  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon-114.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ .Site.BaseURL }}assets/images/favicons/favicon-114.png">
   <!-- 144x144 (precomposed) for iPad 3rd and 4th generation -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ .Site.BaseURL }}/assets/images/favicons/favicon-144.png">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ .Site.BaseURL }}assets/images/favicons/favicon-144.png">
 
 <!-- CSS
 ================================================== -->

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,3 +1,3 @@
-  <script src="assets/scripts/main.js"></script>
+<script src="{{ .Site.BaseURL }}assets/scripts/main.js"></script>
 
   <script src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js" id="_fed_an_ua_tag"></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,3 +1,3 @@
 <script src="{{ .Site.BaseURL }}assets/scripts/main.js"></script>
 
-  <script src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js" id="_fed_an_ua_tag"></script>
+<script src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js" id="_fed_an_ua_tag"></script>


### PR DESCRIPTION
Due to the way `hugo` `serves` versus `builds` the website. We're adding a trailing slash to the `baseurl` property in the `config.toml` to have some consistency between `serve` and `build` commands.
### via `gulp website` ( local )

<img width="766" alt="screen shot 2016-02-25 at 4 52 47 pm" src="https://cloud.githubusercontent.com/assets/706004/13335708/5e15582c-dbe0-11e5-86ba-4b89ffa36f98.png">
### via `gulp production build:website` ( build )

<img width="766" alt="screen shot 2016-02-25 at 4 53 34 pm" src="https://cloud.githubusercontent.com/assets/706004/13335707/5e13be4a-dbe0-11e5-9c15-34bca9bf12d0.png">
