### PR TITLE
Fix sticky-navigation transition on iOS

### DIFF
--- a/assets/styles/homepage.scss
+++ b/assets/styles/homepage.scss
@@ -14,7 +14,7 @@ p {
   font-size: 1.7rem;
 }
 
-// Below is an override of .media-link to include exclusion 
+// Below is an override of .media-link to include exclusion
 // of any "text decoration on hover" issues.
 .media_link {
   display: inline-block;

--- a/assets/styles/homepage.scss
+++ b/assets/styles/homepage.scss
@@ -29,6 +29,10 @@ p {
 }
 
 .nav-horizontal {
+  // Force iOS 9+ to transition to sticky on scroll.
+  --webkit-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
+
   // scss-lint:disable SelectorDepth
   background-color: $color-gray-lightest;
   text-align: center;


### PR DESCRIPTION
This patch fixes a scroll event paint issue previously fixed and then
visually regressed in iOS 9+. By forcing GPU-acceleration on the
navigation element, iOS will properly trigger the repaint as the user
scrolls down the page.
