### PR TITLE
Fix typos

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -59,7 +59,7 @@
             <img class="usa-img-circle" src="{{ .Site.BaseURL }}assets/images/proxies_info_sharing.svg" alt="Proxies and information sharing">
           </div>
           <h3 class="usa-graphic-list-heading">Proxies and information sharing</h3>
-          <p class="usa-graphic-list-text">Many government services don’t allow collaborative interactions, making resources harder to access; we’re researching how to include more interactions by proxy. We’re also investigating how agencies can safely share information with each other in a way that creates better user experiences.</p>
+          <p class="usa-graphic-list-text">Many government services don’t allow collaborative interactions, making resources harder to access; we’re researching how to include more interactions by proxy. We’re also investigating how agencies can safely share information with each other in a way that creates better user experiences.</p>
         </div>
       </div>
       <div class="usa-grid">


### PR DESCRIPTION
Oh `UTF-8`. There was definitely a weird entity in there. I'm going to take a look at other `blocks` in this PR and I'll comment / commit if I find any other ones. @ericadeahl @kategarklavs @maya @juliaelman  @carodew 
