### PR TITLE
Add contributing documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+**Description**
+
+*Include a high-level description of the feature or error here including steps
+of how to recreate it if applicable. Include any benefits, challenges, or
+considerations. This can be short and sweet.*
+
+**Ask**
+
+*Describe the desired behavior and what would deem this issue, bug, or feature
+complete.*
+
+**To Do**
+- [ ] Steps
+- [ ] To
+- [ ] Complete/Fix
+
+**Additional Info**
+
+*Include any images, steps to recreate, notes, emojis, or whatever.*
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 **Description**
 
-*Include a high-level description of the feature or error here including steps
-of how to recreate it if applicable. Include any benefits, challenges, or
+*Include a high-level description of the feature or error here, including steps
+for recreating it, if applicable. Include any benefits, challenges, or
 considerations. This can be short and sweet.*
 
 **Ask**
@@ -16,5 +16,6 @@ complete.*
 
 **Additional Info**
 
-*Include any images, steps to recreate, notes, emojis, or whatever.*
+*Include any images, steps to recreate, notes, emojis, or anything else that
+seems pertinent.*
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,12 +9,12 @@ considerations. This can be short and sweet.*
 *Describe the desired behavior and what would deem this issue, bug, or feature
 complete.*
 
-**To Do**
+**To do**
 - [ ] Steps
 - [ ] To
-- [ ] Complete/Fix
+- [ ] Complete/fix
 
-**Additional Info**
+**Additional info**
 
 *Include any images, steps to recreate, notes, emojis, or anything else that
 seems pertinent.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,16 @@ contributors do the same.
 
  Section | Description
  ------- | -----------
- [Opening an Issue](#opening-an-issue) | Information on contributing Issues
- [Submitting Pull Requests](#submitting-pull-requests) | Information on contributing Pull Requests
- [Deployment Cycle](#deployment-cycle) | Information on the deployment cycle
+ [Opening an issue](#opening-an-issue) | Information on contributing issues
+ [Submitting pull requests](#submitting-pull-requests) | Information on contributing pull requests
+ [Deployment cycle](#deployment-cycle) | Information on the deployment cycle
 
-## Opening an Issue
+## Opening an issue
 
-Before submitting a new Issue, please consider the following guidelines:
+Before submitting a new issue, please consider the following guidelines:
 
 - Search [this repository for open or closed Issues] [gh-search-issue] that may
-  relate to your Pull Request.
+  relate to your pull request.
 
 To help us get a better understanding of the issue you are submitting, please
 use the following outline (as inspired by the following
@@ -28,12 +28,12 @@ use the following outline (as inspired by the following
 [gh-search-issue]: https://github.com/18F/ffd-microsite/issues?utf8=✓&q=is%3Aissue "Github: Search All Issues"
 [ffd-issue-template]: .github/ISSUE_TEMPLATE.md "Federal Front Door: Issue Template"
 
-## Submitting Pull Requests
+## Submitting pull requests
 
-Before submitting your Pull Request, please consider the following guidelines:
+Before submitting your pull request, please consider the following guidelines:
 
 - Search [this repository for open or closed PRs] [gh-search-pr] that may relate
-  to your Pull Request.
+  to your pull request.
 - Make your changes in a new git branch from the remote `staging` branch.
   ```sh
   git fetch --all
@@ -51,11 +51,11 @@ locally_] [ffd-build-local].
 All new Pull Requests must target this repository's `staging` branch. You can
 use [this link to ensure the base branch is set correctly] [gh-base-branch].
 
-[gh-search-pr]: https://github.com/18F/ffd-microsite/pulls?utf8=✓&q=is%3Apr "Github: Search All Pull Requests"
-[gh-base-branch]: https://github.com/18F/ffd-microsite/compare/staging...staging "Github: Submit a new Pull Request"
+[gh-search-pr]: https://github.com/18F/ffd-microsite/pulls?utf8=✓&q=is%3Apr "Github: Search All pull requests"
+[gh-base-branch]: https://github.com/18F/ffd-microsite/compare/staging...staging "Github: Submit a new pull request"
 [ffd-build-local]: README.md#building-the-microsite-locally "Federal Front Door: Building the microsite locally"
 
-## Deployment Cycle
+## Deployment cycle
 
 The deployment cycle for pushing to the production site is every __[x days,
 weeks, etc.]__. A core team member will open a pull request from `staging`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ contributors do the same.
 
  Section | Description
  ------- | -----------
+ [README](README.md) | Information about the project
  [Opening an issue](#opening-an-issue) | Information on contributing issues
  [Submitting pull requests](#submitting-pull-requests) | Information on contributing pull requests
  [Deployment cycle](#deployment-cycle) | Information on the deployment cycle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ contributors do the same.
 
 Before submitting a new issue, please consider the following guidelines:
 
-- Search [this repository for open or closed Issues] [gh-search-issue] that may
+- Search [this repository for open or closed issues] [gh-search-issue] that may
   relate to your pull request.
 
 To help us get a better understanding of the issue you are submitting, please
@@ -49,7 +49,7 @@ locally_] [ffd-build-local].
 - Ensure that there are no errors or warnings.
 - Commit your changes.
 
-All new Pull Requests must target this repository's `staging` branch. You can
+All new pull requests must target this repository's `staging` branch. You can
 use [this link to ensure the base branch is set correctly] [gh-base-branch].
 
 [gh-search-pr]: https://github.com/18F/ffd-microsite/pulls?utf8=✓&q=is%3Apr "Github: Search All pull requests"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to the Federal Front Door Microsite
+
+We aspire to create a welcoming environment for collaboration on this project.
+To that end, we follow the [18F Code of Conduct] [18f-coc] and ask that all
+contributors do the same.
+
+[18f-coc]: https://github.com/18F/code-of-conduct/blob/master/code-of-conduct.md "18F: Code of Conduct"
+
+ Section | Description
+ ------- | -----------
+ [Opening an Issue](#opening-an-issue) | Information on contributing Issues
+ [Submitting Pull Requests](#submitting-pull-requests) | Information on contributing Pull Requests
+ [Deployment Cycle](#deployment-cycle) | Information on the deployment cycle
+
+## Opening an Issue
+
+Before submitting a new Issue, please consider the following guidelines:
+
+- Search [this repository for open or closed Issues] [gh-search-issue] that may
+  relate to your Pull Request.
+
+To help us get a better understanding of the issue you are submitting, please
+leverage the following outline (as used in the following
+[Girl Develop It issue template](https://github.com/girldevelopit/gdi-new-site/issues/83))
+
+[View the ISSUE_TEMPLATE.md in this repository] [ffd-issue-template].
+
+[gh-search-issue]: https://github.com/18F/ffd-microsite/issues?utf8=✓&q=is%3Aissue "Github: Search All Issues"
+[ffd-issue-template]: .github/ISSUE_TEMPLATE.md "Federal Front Door: Issue Template"
+
+## Submitting Pull Requests
+
+Before submitting your Pull Request, please consider the following guidelines:
+
+- Search [this repository for open or closed PRs] [gh-search-pr] that may relate
+  to your Pull Request.
+- Make your changes in a new git branch from the remote `staging` branch.
+  ```sh
+  git fetch --all
+  git checkout -b my-branch origin/staging
+  ```
+- Test your changes by following the instructions on [_Building the microsite
+locally_] [ffd-build-local].
+  ```sh
+  npm test
+  npm run build
+  ```
+- Ensure that there are no errors or warnings.
+- Commit your changes.
+
+All new Pull Requests must target this repository's `staging` branch. You can
+use [this link to ensure the base branch is set correctly] [gh-base-branch].
+
+[gh-search-pr]: https://github.com/18F/ffd-microsite/pulls?utf8=✓&q=is%3Apr "Github: Search All Pull Requests"
+[gh-base-branch]: https://github.com/18F/ffd-microsite/compare/staging...staging "Github: Submit a new Pull Request"
+[ffd-build-local]: README.md#building-the-microsite-locally "Federal Front Door: Building the microsite locally"
+
+## Deployment Cycle
+
+The deploy cycle for pushing to the production site is every __[x days, weeks,
+etc.]__. A core team member will open a pull request from `staging` against
+`master` for a final sanity check. Once merged into `master` the code will be
+live and ready for viewing.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ To help us get a better understanding of the issue you are submitting, please
 use the following outline (as inspired by the following
 [Girl Develop It issue template](https://github.com/girldevelopit/gdi-new-site/issues/83))
 
-[View the ISSUE_TEMPLATE.md in this repository] [ffd-issue-template].
+[View the `ISSUE_TEMPLATE.md` file in this repository] [ffd-issue-template].
 
 [gh-search-issue]: https://github.com/18F/ffd-microsite/issues?utf8=✓&q=is%3Aissue "Github: Search All Issues"
 [ffd-issue-template]: .github/ISSUE_TEMPLATE.md "Federal Front Door: Issue Template"
@@ -58,10 +58,10 @@ use [this link to ensure the base branch is set correctly] [gh-base-branch].
 
 ## Deployment cycle
 
-The deployment cycle for pushing to the production site is every __[x days,
-weeks, etc.]__. A core team member will open a pull request from `staging`
-against `master` for a final sanity check. Once we merge the code into `master`,
-it will be live and ready for viewing [at our `production` URL] [ffd-production].
+Deployments to production occurs as needed. A core team member will open a pull
+request from `staging` against `master` for a final sanity check. Once we merge
+the code into `master`, it will be live and ready for viewing [at our `production`
+URL] [ffd-production].
 
 [ffd-production]: https://labs.usa.gov "Federal Front Door: Production"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Before submitting a new Issue, please consider the following guidelines:
   relate to your Pull Request.
 
 To help us get a better understanding of the issue you are submitting, please
-leverage the following outline (as used in the following
+use the following outline (as inspired by the following
 [Girl Develop It issue template](https://github.com/girldevelopit/gdi-new-site/issues/83))
 
 [View the ISSUE_TEMPLATE.md in this repository] [ffd-issue-template].
@@ -57,8 +57,10 @@ use [this link to ensure the base branch is set correctly] [gh-base-branch].
 
 ## Deployment Cycle
 
-The deploy cycle for pushing to the production site is every __[x days, weeks,
-etc.]__. A core team member will open a pull request from `staging` against
-`master` for a final sanity check. Once merged into `master` the code will be
-live and ready for viewing.
+The deployment cycle for pushing to the production site is every __[x days,
+weeks, etc.]__. A core team member will open a pull request from `staging`
+against `master` for a final sanity check. Once we merge the code into `master`,
+it will be live and ready for viewing [at our `production` URL] [ffd-production].
+
+[ffd-production]: https://labs.usa.gov "Federal Front Door: Production"
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Door Microsite.
 
  Section | Description
  ------- | -----------
- [Installation](#installation) | Installing the project locally.
- [Development](#development)   | Development workflow using `gulp`.
- [Deployment](#deployment)     | Automated and Manual deployment information using `cloud.gov`.
+ [Installation](#installation)   | Installing the project locally.
+ [Development](#development)     | Development workflow using `gulp`.
+ [Deployment](#deployment)       | Automated and Manual deployment information using `cloud.gov`.
+ [Contributing](CONTRIBUTING.md) | Contributing to the project
 
 ## Installation
 


### PR DESCRIPTION
This patch adds the contributing documentation to the repo along with an
ISSUE_TEMPLATE file.

~~This is a _work in progress_.~~ Any input would be greatly appreciated. I have copied the `ISSUES_TEMPLATE` from 18F/web-design-standards#1010. 

I'm including some line-notes around the parts I would like help with.

CC: @juliaelman @kategarklavs @maya @yozlet 
