### PR TITLE
Update `stylesheets` task to leverage `production`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Thumbs.db
 
 # Node modules
 node_modules/
+npm-debug.log
 
 # Compiled or Bundled Static Assets
 /static/assets/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,11 +96,17 @@ gulp.task('styles:homepage', [ 'scss-lint' ], function () {
         '\n',
         error.messageFormatted
       );
+
+      if (cFlags.production) {
+        process.exit(1);
+      }
+
       this.emit('end');
     })
     .pipe(gulp.dest('./static/assets/styles'));
 
   return stream;
+
 
 });
 


### PR DESCRIPTION
This patch leverages the `production` flag to properly crash if there is
an error in the compiling of the `stylesheets` task.
