### PR TITLE
Add HTMLProofer tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: go
 go:
 - 1.5.1
 - tip
+before_install:
+  - rvm install 2.2.3
+  - nvm install 5.5
 install:
 - go get -u -v github.com/spf13/hugo
-- gem install scss_lint
 - npm install
 script:
 - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ install:
 - gem install scss_lint
 - npm install
 script:
-- gulp
 - npm test
-- gulp production build:website
+- npm run build
 env:
   - SITE_BASEURL_PRODUCTION="https://labs.usa.gov/" SITE_BASEURL_STAGING="https://ffd-microsite-staging.apps.cloud.gov/"
 deploy:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "postinstall": "gem install html-proofer",
     "start": "gulp && gulp clean-all && gulp website",
-    "build": "gulp production build:website && htmlproofer ./public",
+    "build": "gulp production build:website && htmlproofer ./public --disable-external",
     "test": "gulp scss-lint eslint"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {
+    "postinstall": "gem install html-proofer",
     "start": "gulp && gulp clean-all && gulp website",
-    "build": "gulp production build:website",
+    "build": "gulp production build:website && htmlproofer ./public",
     "test": "gulp scss-lint eslint"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "scripts": {
-    "postinstall": "gem install html-proofer",
+    "postinstall": "gem install html-proofer scss_lint",
     "start": "gulp && gulp clean-all && gulp website",
     "build": "gulp production build:website && htmlproofer ./public --disable-external",
     "test": "gulp scss-lint eslint"


### PR DESCRIPTION
This patch introduces html-proofer tests to the microsite. This is a
Ruby library commonly used for testing Jekyll static sites. It's
recommended for CI [in the Jekyll documentation itself](http://jekyllrb.com/docs/continuous-integration/#the-test-script).
After `npm install` is run, the `postinstall` hook will install the gem
globally on the machine. The `npm run build` script has been updated to
run `htmlproofer` with external link checking on whatever platform is
being deployed to. The build can fail for a number of reasons related to
links in the html files. For more information on `htmlproofer`, [check
out the Github repo](https://github.com/gjtorikian/html-proofer).
